### PR TITLE
Fix/ascii2d

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-image-search",
   "description": "Image searching plugin for Koishi",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "cheerio": "^1.0.0-rc.10",
     "iqdb-client": "^1.1.0",
     "nhentai-api": "^3.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23"
   }
 }

--- a/src/ascii2d.ts
+++ b/src/ascii2d.ts
@@ -1,6 +1,11 @@
+import tls from 'tls'
 import Cheerio from 'cheerio'
 import { Session, Logger } from 'koishi'
 import { getShareText } from './utils'
+
+//lock openssl version to pass cloudflare
+tls.DEFAULT_MAX_VERSION = 'TLSv1.1'
+tls.DEFAULT_MIN_VERSION = 'TLSv1.1'
 
 const baseURL = 'https://ascii2d.net'
 const logger = new Logger('search')
@@ -8,7 +13,11 @@ const logger = new Logger('search')
 export default async function (url: string, session: Session) {
   try {
     const tasks: Promise<string[]>[] = []
-    const response = await session.app.http.axios(`${baseURL}/search/url/${encodeURIComponent(url)}`)
+    const response = await session.app.http.axios(`${baseURL}/search/url/${encodeURIComponent(url)}`,{
+      headers: {
+        'User-Agent': 'PostmanRuntime/7.29.0'
+      }
+    })
     tasks.push(session.send('ascii2d 色合检索\n' + getDetail(response.data)))
     try {
       const bovwURL = response.request.res.responseUrl.replace('/color/', '/bovw/')

--- a/src/ascii2d.ts
+++ b/src/ascii2d.ts
@@ -3,7 +3,7 @@ import Cheerio from 'cheerio'
 import { Session, Logger } from 'koishi'
 import { getShareText } from './utils'
 
-//lock openssl version to pass cloudflare
+// lock openssl version to pass cloudflare
 tls.DEFAULT_MAX_VERSION = 'TLSv1.1'
 tls.DEFAULT_MIN_VERSION = 'TLSv1.1'
 
@@ -13,10 +13,10 @@ const logger = new Logger('search')
 export default async function (url: string, session: Session) {
   try {
     const tasks: Promise<string[]>[] = []
-    const response = await session.app.http.axios(`${baseURL}/search/url/${encodeURIComponent(url)}`,{
+    const response = await session.app.http.axios(`${baseURL}/search/url/${encodeURIComponent(url)}`, {
       headers: {
-        'User-Agent': 'PostmanRuntime/7.29.0'
-      }
+        'User-Agent': 'PostmanRuntime/7.29.0',
+      },
     })
     tasks.push(session.send('ascii2d 色合检索\n' + getDetail(response.data)))
     try {


### PR DESCRIPTION
尝试修复：ascii2d接口调用报403的问题（https://github.com/koishijs/koishi-plugin-image-search/issues）
解决方法：锁定openssl的版本为1.1，并在请求header中添加Postman7.29的UA，参照实现：https://github.com/Tsuk1ko/cq-picsearcher-bot/issues/283
测试：ubuntu 18.04 ( openssl 1.1 / 1.0 ),centos 7( openssl 1.1 )通过