### PR TITLE
refa: use http.get instead of http.axios

### DIFF
--- a/src/ascii2d.ts
+++ b/src/ascii2d.ts
@@ -8,14 +8,14 @@ const logger = new Logger('search')
 export default async function (url: string, session: Session) {
   try {
     const tasks: Promise<string[]>[] = []
-    const response = await session.app.http.axios(`${baseURL}/search/url/${encodeURIComponent(url)}`, {
+    const colorHTML = await session.app.http.get(`${baseURL}/search/url/${encodeURIComponent(url)}`, {
       headers: {
         'User-Agent': 'PostmanRuntime/7.29.0',
       },
     })
-    tasks.push(session.send('ascii2d 色合检索\n' + getDetail(response.data)))
+    tasks.push(session.send('ascii2d 色合检索\n' + getDetail(colorHTML)))
     try {
-      const bovwURL = getTokujouUrl(response.data)
+      const bovwURL = getTokujouUrl(colorHTML)
       const bovwHTML = await session.app.http.get(bovwURL)
       tasks.push(session.send('ascii2d 特征检索\n' + getDetail(bovwHTML)))
     } catch (err) {


### PR DESCRIPTION
This is the following up refactor for #4 , as
we don't need to read the response object,
it is better to switch to the easier `get` function.