### PR TITLE
fix(ascii2d): changed to ascii2d GET interface, fix #26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-image-search",
   "description": "Image searching plugin for Koishi",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
@@ -42,7 +42,7 @@
     }
   },
   "peerDependencies": {
-    "koishi": "^4.16.3"
+    "koishi": "^4.17.0"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.2",
-    "koishi": "^4.16.3",
+    "koishi": "^4.17.0",
     "typescript": "^5.3.2"
   }
 }

--- a/src/ascii2d.ts
+++ b/src/ascii2d.ts
@@ -1,7 +1,6 @@
 import { load } from 'cheerio'
 import { Logger, Quester, Session } from 'koishi'
 import { Config, getShareText, OutputConfig } from './utils'
-import FormData from 'form-data'
 
 const baseURL = 'https://ascii2d.net'
 const logger = new Logger('search')
@@ -9,14 +8,11 @@ const logger = new Logger('search')
 export default async function (http: Quester, url: string, session: Session, config: Config) {
   try {
     const tasks: Promise<string[]>[] = []
-    const form = new FormData()
-    form.append('file', await http.get(url, { responseType: 'stream' }))
-    const colorHTML = await http.post(`${baseURL}/search/file`, form, {
+    const colorHTML = await http.get(`${baseURL}/search/url/${encodeURIComponent(url)}`,{
       headers: {
-        'User-Agent': 'PostmanRuntime/7.29.0',
-        ...form.getHeaders(),
+          'User-Agent': 'PostmanRuntime/7.29.0',
       },
-    })
+    });
     tasks.push(session.send('ascii2d 色合检索\n' + getDetail(colorHTML, config.output)))
     try {
       const bovwURL = getTokuchouUrl(colorHTML)

--- a/src/ascii2d.ts
+++ b/src/ascii2d.ts
@@ -12,7 +12,7 @@ export default async function (http: Quester, url: string, session: Session, con
       headers: {
           'User-Agent': 'PostmanRuntime/7.29.0',
       },
-    });
+    })
     tasks.push(session.send('ascii2d 色合检索\n' + getDetail(colorHTML, config.output)))
     try {
       const bovwURL = getTokuchouUrl(colorHTML)


### PR DESCRIPTION
修改为 ascii2d 的 GET 接口，以节省请求资源，并规避高版本 koishi 下 Formdata 报错而无法使用 ascii2d 接口的错误。