### PR TITLE
upgrade iqdb-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
-    "iqdb-client": "^1.1.0",
+    "iqdb-client": "^3.0.0",
     "nhentai-api": "^3.4.3"
   },
   "devDependencies": {

--- a/src/iqdb.ts
+++ b/src/iqdb.ts
@@ -1,4 +1,4 @@
-import { searchPic } from 'iqdb-client'
+import { searchPic, IQDB_RESULT_TYPE } from 'iqdb-client'
 import { Quester, segment, Session } from 'koishi'
 
 async function makeSearch(url: string): Promise<string> {
@@ -6,8 +6,9 @@ async function makeSearch(url: string): Promise<string> {
   if ('err' in res) {
     return '搜图时遇到问题：' + res.err
   } else if (res.ok || (res.data && res.data.length > 1)) {
-    const data: any = res.data[1]
-    const { head, sourceUrl, img, type, source } = data
+    const data = res.data[1]
+    const { head, sourceUrl, img, source } = data
+    const type: IQDB_RESULT_TYPE = (data as any).type
 
     return [
       segment('image', { url: 'https://iqdb.org' + img }),


### PR DESCRIPTION
Fix:
```
(node:9536) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
    at node:punycode:3:9
    at BuiltinModule.compileForInternalLoader (node:internal/bootstrap/realm:398:7)
    at BuiltinModule.compileForPublicLoader (node:internal/bootstrap/realm:337:10)
    at loadBuiltinModule (node:internal/modules/helpers:96:7)
    at Module._load (node:internal/modules/cjs/loader:1037:17)
    at Module.require (node:internal/modules/cjs/loader:1271:19)
    at require (node:internal/modules/helpers:123:16)
    at Object.<anonymous> (F:\koishi-dev\node_modules\whatwg-url\lib\url-state-machine.js:2:18)
    at Module._compile (node:internal/modules/cjs/loader:1434:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1518:10)
```


Additional information: https://github.com/KotoriK/iqdb-client?tab=readme-ov-file#break-changes